### PR TITLE
Closes #7 - Change category slugs from id numbers to category_name

### DIFF
--- a/app/controllers/oil_types_controller.rb
+++ b/app/controllers/oil_types_controller.rb
@@ -4,7 +4,8 @@ class OilTypesController < ApplicationController
   end
 
   def show
-    @oil_type = OilType.find(params[:id])
+    name = OilType.storage_name(params[:name])
+    @oil_type = OilType.find_by(name: name)
     @chips = @oil_type.chips
   end
 end

--- a/app/models/oil_type.rb
+++ b/app/models/oil_type.rb
@@ -1,3 +1,12 @@
 class OilType < ActiveRecord::Base
   has_many :chips
+  validates :name, presence: true, uniqueness: true
+
+  def name_id
+    name.downcase.gsub(" ", "_")
+  end
+
+  def self.storage_name(downcased_name)
+    downcased_name.gsub("_", " ").split.map(&:capitalize).join(' ')
+  end
 end

--- a/app/views/oil_types/index.html.erb
+++ b/app/views/oil_types/index.html.erb
@@ -1,5 +1,5 @@
-<div class="chips">
+<div class="categories">
   <% @oil_types.each do |oil_type| %>
-    <%= link_to oil_type.name, oil_type_path(oil_type) %>
+    <%= link_to oil_type.name, oil_type_path(oil_type.name_id) %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :chips, only: [:index]
-  resources :oil_types, only: [:index, :show]
+  resources :oil_types, only: [:index, :show], param: :name
 end

--- a/test/integration/visitor_can_view_items_test.rb
+++ b/test/integration/visitor_can_view_items_test.rb
@@ -25,9 +25,11 @@ class VisitorCanViewItemsTest < ActionDispatch::IntegrationTest
     item_3 = Chip.create(name: "Dang Coconut", price: 17, description: "Dang, these are good", oil_type_id: category_2.id)
     item_4 = Chip.create(name: "Lard Yummies", price: 19, description: "Chock Full of Lard", oil_type_id: category_1.id)
 
-    visit '/oil_types'
+    visit oil_types_path
 
     click_link "Lard"
+
+    assert current_path, '/oil_types/lard'
 
     within(".chips") do
       assert page.has_content?("Slotachips")
@@ -37,6 +39,8 @@ class VisitorCanViewItemsTest < ActionDispatch::IntegrationTest
     click_link "Return to oil types"
 
     click_link "Coconut Oil"
+
+    assert current_path, '/oil_types/coconut_oil'
 
     within(".chips") do
       assert page.has_content?("Trader Joe's BBQ")

--- a/test/models/oil_type_test.rb
+++ b/test/models/oil_type_test.rb
@@ -1,7 +1,35 @@
 require 'test_helper'
 
 class OilTypeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "an oil type category can be created with valid attributes" do
+    oil_type = OilType.new(name: "Lard")
+
+    assert oil_type.valid?
+    assert_equal "Lard", oil_type.name
+  end
+
+  test "an oil type category can not be created without a name" do
+    oil_type = OilType.new()
+
+    assert oil_type.invalid?
+  end
+
+  test "an oil type category can not be created without a unique name" do
+    oil_type1 = OilType.create(name: "Lard")
+    oil_type2 = OilType.new(name: "Lard")
+
+    assert oil_type2.invalid?
+  end
+
+  test "a category name is rewritten as an appropriate slug" do
+    oil_type = OilType.new(name: "Coconut Oil")
+
+    assert_equal "coconut_oil", oil_type.name_id
+  end
+
+  test "a slug is rewritten to it's category name" do
+    slug = "coconut_oil"
+
+    assert_equal "Coconut Oil", OilType.storage_name(slug)
+  end
 end


### PR DESCRIPTION
Update validation so name attribute in categories is unique. Added model
tests. Change name to acceptable slug form and back again. Updated feature test
to reflect new url structure.