### PR TITLE
Admin can update order status

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,4 +2,14 @@ class Admin::OrdersController < Admin::BaseController
   def index
     @orders = Order.scope_action(params[:scope])
   end
+
+  def update
+    @order = Order.find(params[:id])
+    @order.status_update(params[:new_status])
+    if @order.save
+      redirect_to dashboard_path
+    else
+      # something
+    end
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,13 +9,23 @@ class Order < ActiveRecord::Base
 
   def update_links
     if status == "Ordered"
-      links = "[mark as paid] [cancel]"
+      links = ["[mark as paid]", "[cancel]"]
     elsif status == "Paid"
-      links = "[mark as complete] [cancel]"
+      links = ["[mark as complete]", "[cancel]"]
     else
-      links = nil
+      links = []
     end
     links
+  end
+
+  def status_update(new_status)
+    if new_status == "[cancel]"
+      self.status = "Cancelled"
+    elsif new_status == "[mark as paid]"
+      self.status = "Paid"
+    elsif new_status == "[mark as complete]"
+      self.status = "Complete"
+    end
   end
 
   def size_of_order

--- a/app/views/admin/orders/_order.html.erb
+++ b/app/views/admin/orders/_order.html.erb
@@ -1,4 +1,7 @@
 <div id="order-<%=order.id%>">
   <%= link_to "Order #{order.id}", order_path(order)%>
-  | <%= order.status %> | <%= order.update_links %>
+  | <%= order.status %> |
+  <% order.update_links.each do |link_name| %>
+    <%= link_to link_name, admin_order_path(order, new_status: link_name), method: :patch %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :chips, only: [:index, :show, :create, :new, :update, :edit, :destroy]
     resources :dashboard, only: [:index, :show]
-    resources :orders, only: [:index]
+    resources :orders, only: [:index, :update]
  end
 
   get '/login', to: 'sessions#new'

--- a/test/integration/admin_can_view_orders_test.rb
+++ b/test/integration/admin_can_view_orders_test.rb
@@ -11,7 +11,6 @@ class AdminCanViewOrdersTest < ActionDispatch::IntegrationTest
   test "admin can view the dashboard" do
     create_admin
     login_admin
-    visit "/admin/dashboard"
 
     assert page.has_content?("Admin Dashboard")
   end
@@ -38,7 +37,9 @@ class AdminCanViewOrdersTest < ActionDispatch::IntegrationTest
     order2 = create_order("Paid", 6, user.id)
     order3 = create_order("Cancelled", 7, user.id)
     order4 = create_order("Completed", 8, user.id)
-    login_admin_to_dashboard
+
+    create_admin
+    login_admin
 
     within("#order-#{order1.id}") do
       assert page.has_content?("#{order1.id}")
@@ -81,7 +82,9 @@ class AdminCanViewOrdersTest < ActionDispatch::IntegrationTest
     order5 = create_order("Cancelled", 7, 3)
     order6 = create_order("Cancelled", 7, 3)
     order7 = create_order("Completed", 8, 4)
-    login_admin_to_dashboard
+
+    create_admin
+    login_admin
 
     assert page.has_content?("Total Orders: 7")
     assert page.has_content?("Ordered (3)")
@@ -129,7 +132,9 @@ class AdminCanViewOrdersTest < ActionDispatch::IntegrationTest
   test "admin can click on an order link to view more details" do
     user = create_user
     order = create_order("Ordered", 5, user.id)
-    login_admin_to_dashboard
+
+    create_admin
+    login_admin
 
     assert page.has_link?("Order #{Order.all.last.id}")
 
@@ -139,29 +144,84 @@ class AdminCanViewOrdersTest < ActionDispatch::IntegrationTest
     assert page.has_content?
   end
 
-  test "admin can fliter order by order type" do
-    skip
-    login_admin_to_dashboard
-  end
-
   test "admin can cancel a 'paid' order" do
-    skip
-    login_admin_to_dashboard
+    user = create_user
+    order1 = create_order("Paid", 5, user.id)
+
+    create_admin
+    login_admin
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Paid")
+      click_link "[cancel]"
+    end
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Cancelled")
+      refute page.has_content?("[mark as paid]")
+      refute page.has_content?("[mark as complete]")
+      refute page.has_content?("[cancel]")
+    end
   end
 
   test "admin can cancel an 'ordered' order" do
-    skip
-    login_admin_to_dashboard
+    user = create_user
+    order1 = create_order("Ordered", 5, user.id)
+
+    create_admin
+    login_admin
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Ordered")
+      click_link "[cancel]"
+    end
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Cancelled")
+      refute page.has_content?("[mark as paid]")
+      refute page.has_content?("[mark as complete]")
+      refute page.has_content?("[cancel]")
+    end
   end
 
   test "admin can mark an 'ordered' order as 'paid'" do
-    skip
-    login_admin_to_dashboard
+    user = create_user
+    order1 = create_order("Ordered", 5, user.id)
+
+    create_admin
+    login_admin
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Ordered")
+      click_link "[mark as paid]"
+    end
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Paid")
+      refute page.has_content?("[mark as paid]")
+      assert page.has_content?("[mark as complete]")
+      assert page.has_content?("[cancel]")
+    end
   end
 
   test "admin can mark a 'paid' order as 'completed'" do
-    skip
-    login_admin_to_dashboard
+    user = create_user
+    order1 = create_order("Paid", 5, user.id)
+
+    create_admin
+    login_admin
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Paid")
+      click_link "[mark as complete]"
+    end
+
+    within("#order-#{order1.id}") do
+      assert page.has_content?("Complete")
+      refute page.has_content?("[mark as paid]")
+      refute page.has_content?("[mark as complete]")
+      refute page.has_content?("[cancel]")
+    end
   end
 
 end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -17,4 +17,48 @@ class OrderTest < ActiveSupport::TestCase
 
     assert_equal 2, order.chip_orders.all.count
   end
+
+  test "an order can return it's status update links" do
+    user = create_user
+    order = user.orders.create(total_price: 20)
+
+    expected = ["[mark as paid]", "[cancel]"]
+    assert_equal expected, order.update_links
+
+    order.status = "Paid"
+    expected = ["[mark as complete]", "[cancel]"]
+    assert_equal expected, order.update_links
+
+    order.status = "Cancelled"
+    expected = []
+    assert_equal expected, order.update_links
+
+    order.status = "Completed"
+    expected = []
+    assert_equal expected, order.update_links
+  end
+
+  test "an order's status can be changed" do
+    user = create_user
+    order = user.orders.create(total_price: 20)
+
+    assert_equal "Ordered", order.status
+    order.status_update("[cancel]")
+    assert_equal "Cancelled", order.status
+
+    order.status = "Ordered"
+    assert_equal "Ordered", order.status
+    order.status_update("[mark as paid]")
+    assert_equal "Paid", order.status
+
+    order.status = "Paid"
+    assert_equal "Paid", order.status
+    order.status_update("[mark as complete]")
+    assert_equal "Complete", order.status
+
+    order.status = "Paid"
+    assert_equal "Paid", order.status
+    order.status_update("[cancel]")
+    assert_equal "Cancelled", order.status
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -99,12 +99,6 @@ class ActionDispatch::IntegrationTest
     click_link("View Order Details")
   end
 
-  def login_admin_to_dashboard
-    create_admin
-    login_admin
-    visit '/admin/dashboard'
-  end
-
   def create_order(status, price, user_id)
     Order.create(status: status, total_price: price, user_id: user_id)
   end


### PR DESCRIPTION
New update status method in order model (with tests). Index updated to provide status update links
instead of plaintext.